### PR TITLE
feat: allow port config in the redirect URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = function enforceHTTPS() {
+module.exports = function enforceHTTPS(opts) {
 
 	return function(req, res, next) {
 
@@ -9,15 +9,19 @@ module.exports = function enforceHTTPS() {
 		if (isHttps) {
 			next();
 		} else {
-			redirectUrl(req, res);
+			redirectUrl(req, res, opts);
 		}
 	};
 
 };
 
-var redirectUrl = function (req, res) {
+var redirectUrl = function (req, res, opts) {
+	var port = '';
+	if (opts && opts.port) {
+		port = ':' + opts.port;
+	}
 	if (req.method === "GET") {
-		res.redirect(301, "https://" + req.headers.host + req.originalUrl);
+		res.redirect(301, "https://" + req.hostname + port + req.originalUrl);
 	} else {
 		res.status(403).send("Please use HTTPS when submitting data to this server.");
 	}


### PR DESCRIPTION
```
app.use(express_enforces_ssl({port: 8443}));
```

Closes #4 at the same time
